### PR TITLE
Clearer naming added to BookSuper and possible bug fix in BookDao

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ohjelmistotuotannon miniprojekti
 
+
+
 ## Sovelluksen määrittely
 
 - Tästä tulee sovellus, jonka avulla käyttäjä voi hallinnoida lukuvinkkejä

--- a/src/main/java/ohtu/dao/BookDao.java
+++ b/src/main/java/ohtu/dao/BookDao.java
@@ -133,7 +133,7 @@ public class BookDao implements Dao<BookSuper, String> {
 
   @Override
   public void update(BookSuper book, BookSuper updatedBook) throws SQLException {
-    if (book instanceof Book && book instanceof Book) {
+    if (book instanceof Book && updatedBook instanceof Book) {
         Connection connection = DriverManager.getConnection(url);
         PreparedStatement stmt = connection
         .prepareStatement("UPDATE Books SET title = ? , author = ? WHERE title = ? AND author = ?");
@@ -204,6 +204,8 @@ public class BookDao implements Dao<BookSuper, String> {
       Book book = new Book(title, author);
       list.add(book);
     }
+
+    stmt.close();
     
     stmt = connection.prepareStatement("SELECT * FROM AUDIOBOOKS");
     resultSet = stmt.executeQuery();

--- a/src/main/java/ohtu/objects/BookSuper.java
+++ b/src/main/java/ohtu/objects/BookSuper.java
@@ -38,26 +38,26 @@ public abstract class BookSuper implements Comparable<BookSuper> {
     }
 
     @Override
-    public boolean equals(Object b) {
-        if (!(b instanceof BookSuper))
+    public boolean equals(Object bookToCompare) {
+        if (!(bookToCompare instanceof BookSuper))
             return false;
-        BookSuper book = (BookSuper) b;
+        BookSuper book = (BookSuper) bookToCompare;
         return ((book.getAuthor()).equalsIgnoreCase(author) && book.getTitle().equalsIgnoreCase(title));
     }
 
     @Override
     public int compareTo(BookSuper book) {
-        return Comparator.comparing(BookSuper::getAuthor, (a1, a2) -> {
-            return a1.toLowerCase().compareTo(a2.toLowerCase());
-        }).thenComparing(BookSuper::getTitle, (a1, a2) -> {
-            return a1.toLowerCase().compareTo(a2.toLowerCase());
+        return Comparator.comparing(BookSuper::getAuthor, (author1, author2) -> {
+            return author1.toLowerCase().compareTo(author2.toLowerCase());
+        }).thenComparing(BookSuper::getTitle, (title1, title2) -> {
+            return title1.toLowerCase().compareTo(title2.toLowerCase());
         }).compare(this, book);
     }
 
-    public boolean equalsCaseSensitive(Object b) {
-        if (!(b instanceof BookSuper))
+    public boolean equalsCaseSensitive(Object bookToCompare) {
+        if (!(bookToCompare instanceof BookSuper))
             return false;
-        BookSuper book = (BookSuper) b;
+        BookSuper book = (BookSuper) bookToCompare;
         return ((book.getAuthor()).equals(author) && book.getTitle().equals(title));
     }
 }


### PR DESCRIPTION
Muutin joidenkin muuttujien nimiä BookSuper-luokassa hieman kuvaavammiksi, koska ajattelin, että se selkeyttäisi, että mitä koodissa tehdään. Lisäksi muokkasin BookDaossa kohtaa, jossa kaksi kertaa peräkkäin testattiin saman if-lauseen ehtona samaa muuttujan book luokkaa. Oletin, että toisen verrattavan kuuluisi olla updatedBook.